### PR TITLE
Avoid multiple migrations with the same version number and action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.12
+      - image: circleci/node:10.20
       - image: circleci/postgres:9.6-alpine-ram
         environment:
           POSTGRES_USER: postgrator

--- a/postgrator.js
+++ b/postgrator.js
@@ -100,7 +100,7 @@ class Postgrator extends EventEmitter {
           `${migration.version}:${migration.action}`
         const migrationKeys = new Set()
         migrations.forEach(migration => {
-          const newKey = getMigrationKey(migrationKey)
+          const newKey = getMigrationKey(migration)
           if (migrationKeys.has(newKey)) {
             throw new Error(
               `Two migrations found with version ${migration.version} and action ${migration.action}`

--- a/postgrator.js
+++ b/postgrator.js
@@ -96,6 +96,21 @@ class Postgrator extends EventEmitter {
         migrations.filter(migration => !isNaN(migration.version))
       )
       .then(migrations => {
+        const getMigrationKey = migration =>
+          `${migration.version}:${migration.action}`
+        const migrationKeys = new Set()
+        migrations.forEach(migration => {
+          const newKey = getMigrationKey(migrationKey)
+          if (migrationKeys.has(newKey)) {
+            throw new Error(
+              `Two migrations found with version ${migration.version} and action ${migration.action}`
+            )
+          }
+          migrationKeys.add(newKey)
+        })
+        return migrations
+      })
+      .then(migrations => {
         this.migrations = migrations
         return migrations
       })

--- a/test/duplicateMigrations/001.do.sql
+++ b/test/duplicateMigrations/001.do.sql
@@ -1,0 +1,11 @@
+
+-- create a person table
+CREATE TABLE person (
+	name 	VARCHAR(50),
+	age 	INT
+);
+
+-- to test multiple statements, create another table
+CREATE TABLE animal (
+	kind 	VARCHAR(50)
+);

--- a/test/duplicateMigrations/001.undo.sql
+++ b/test/duplicateMigrations/001.undo.sql
@@ -1,0 +1,3 @@
+-- DROP table
+DROP TABLE animal;
+DROP TABLE person;

--- a/test/duplicateMigrations/002.do.another-description.sql
+++ b/test/duplicateMigrations/002.do.another-description.sql
@@ -1,0 +1,3 @@
+
+-- Test 1 insert
+INSERT INTO person (name, age) VALUES ('bob', 40);

--- a/test/duplicateMigrations/002.do.some-description.sql
+++ b/test/duplicateMigrations/002.do.some-description.sql
@@ -1,0 +1,3 @@
+
+-- Test 1 insert
+INSERT INTO person (name, age) VALUES ('fred', 30);

--- a/test/duplicateMigrations/002.undo.another-description.sql
+++ b/test/duplicateMigrations/002.undo.another-description.sql
@@ -1,0 +1,2 @@
+-- remove the record
+DELETE FROM person WHERE name = 'bob' AND age = 40;

--- a/test/duplicateMigrations/002.undo.some-description.sql
+++ b/test/duplicateMigrations/002.undo.some-description.sql
@@ -1,0 +1,2 @@
+-- remove the record
+DELETE FROM person WHERE name = 'fred' AND age = 30;

--- a/test/migrationDuplicate.js
+++ b/test/migrationDuplicate.js
@@ -1,0 +1,47 @@
+/* global after, it, describe */
+const assert = require('assert')
+const Postgrator = require('../postgrator')
+
+const path = require('path')
+const migrationDirectory = path.join(__dirname, 'duplicateMigrations')
+
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'pg',
+  host: 'localhost',
+  port: 5432,
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})
+
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mysql',
+  host: 'localhost',
+  database: 'postgrator',
+  username: 'postgrator',
+  password: 'postgrator'
+})
+
+testConfig({
+  migrationDirectory: migrationDirectory,
+  driver: 'mssql',
+  host: 'localhost',
+  database: 'master',
+  username: 'sa',
+  password: 'Postgrator123!'
+})
+
+function testConfig(config) {
+  describe(`Driver: ${config.driver}`, function() {
+    const postgrator = new Postgrator(config)
+
+    it('Refuses to run if there are duplicate migrations', function() {
+      assert.rejects(
+        () => postgrator.migrate(),
+        'Error expected from duplicated migrations'
+      )
+    })
+  })
+}

--- a/test/migrationDuplicate.js
+++ b/test/migrationDuplicate.js
@@ -37,8 +37,8 @@ function testConfig(config) {
   describe(`Driver: ${config.driver}`, function() {
     const postgrator = new Postgrator(config)
 
-    it('Refuses to run if there are duplicate migrations', function() {
-      assert.rejects(
+    it('Refuses to run if there are duplicate migrations', async function() {
+      await assert.rejects(
         () => postgrator.migrate(),
         'Error expected from duplicated migrations'
       )


### PR DESCRIPTION
Multiple migrations with the same version number and action can occur in the following scenario:
- You switch between two development branches with conflicting migration histories
- Migrations are copied to another directory as part of a build step

This PR adds a check for this condition, erroring out if it occurs.